### PR TITLE
Always update cache when installing on Debian

### DIFF
--- a/tasks/sysdig_Debian.yml
+++ b/tasks/sysdig_Debian.yml
@@ -26,5 +26,4 @@
 - name: Install Sysdig for Debian OS family
   apt: pkg={{ sysdig_package }} 
        update_cache=yes 
-       cache_valid_time=30
        state=latest


### PR DESCRIPTION
Hi,

I'd like to suggest removing the cache_valid_time=30 argument from the "Install Sysdig for Debian OS family" task, as it will fail with "No package matching 'sysdig' is available" if it has been less than 30 seconds since "Install python-pycurl and python-apt [...]" was run (the apt cache never gets updated after the repo is added).

Thanks for the role!